### PR TITLE
Add CSS class name prefix to prevent conflicting styles when using SVG mode

### DIFF
--- a/src/core/QRSVG.ts
+++ b/src/core/QRSVG.ts
@@ -41,6 +41,7 @@ export default class QRSVG {
   _options: RequiredOptions;
   _qr?: QRCode;
   _image?: HTMLImageElement;
+  _classPrefix: string;
 
   //TODO don't pass all options to this class
   constructor(options: RequiredOptions) {
@@ -50,7 +51,7 @@ export default class QRSVG {
     this._element.setAttribute("xmlns:xlink", "http://www.w3.org/1999/xlink");
     this._defs = document.createElementNS("http://www.w3.org/2000/svg", "defs");
     this._style = document.createElementNS("http://www.w3.org/2000/svg", "style");
-
+    this._classPrefix = this.generateClassPrefix();
     this._options = options;
   }
 
@@ -74,6 +75,10 @@ export default class QRSVG {
     this._style = document.createElementNS("http://www.w3.org/2000/svg", "style");
     this._element.appendChild(this._style);
     this._element.appendChild(this._defs);
+  }
+
+  generateClassPrefix(): string {
+    return Array.from({ length: 8 }, () => Math.floor(Math.random() * 25 + 10).toString(36)).join("");
   }
 
   async drawQR(qr: QRCode): Promise<void> {
@@ -157,12 +162,12 @@ export default class QRSVG {
           y: 0,
           height: options.height,
           width: options.width,
-          name: "background-color"
+          name: `${this._classPrefix}-background-color`
         });
       } else if (options.backgroundOptions?.color) {
         this._createStyle({
           color: color,
-          name: "background-color"
+          name: `${this._classPrefix}-background-color`
         });
       }
     }
@@ -198,15 +203,15 @@ export default class QRSVG {
         y: yBeginning,
         height: count * dotSize,
         width: count * dotSize,
-        name: "dot-color"
+        name: `${this._classPrefix}-dot-color`
       });
     } else if (options.dotsOptions.color) {
       this._dots = document.createElementNS("http://www.w3.org/2000/svg", "g");
-      this._dots.setAttribute("class", "dot-color");
+      this._dots.setAttribute("class", `${this._classPrefix}-dot-color`);
       this._element.appendChild(this._dots);
       this._createStyle({
         color: options.dotsOptions.color,
-        name: "dot-color"
+        name: `${this._classPrefix}-dot-color`
       });
     }
 
@@ -287,15 +292,15 @@ export default class QRSVG {
           y,
           height: cornersSquareSize,
           width: cornersSquareSize,
-          name: `corners-square-color-${column}-${row}`
+          name: `${this._classPrefix}-corners-square-color-${column}-${row}`
         });
       } else {
         this._cornerSquares = document.createElementNS("http://www.w3.org/2000/svg", "g");
-        this._cornerSquares.setAttribute("class", `corners-square-color-${column}-${row}`);
+        this._cornerSquares.setAttribute("class", `${this._classPrefix}-corners-square-color-${column}-${row}`);
         this._element.appendChild(this._cornerSquares);
         this._createStyle({
           color: options.cornersSquareOptions?.color,
-          name: `corners-square-color-${column}-${row}`
+          name: `${this._classPrefix}-corners-square-color-${column}-${row}`
         });
       }
 
@@ -348,15 +353,15 @@ export default class QRSVG {
           y: y + dotSize * 2,
           height: cornersDotSize,
           width: cornersDotSize,
-          name: `corners-dot-color-${column}-${row}`
+          name: `${this._classPrefix}-corners-dot-color-${column}-${row}`
         });
       } else {
         this._cornerDots = document.createElementNS("http://www.w3.org/2000/svg", "g");
-        this._cornerDots.setAttribute("class", `corners-dot-color-${column}-${row}`);
+        this._cornerDots.setAttribute("class", `${this._classPrefix}-corners-dot-color-${column}-${row}`);
         this._element.appendChild(this._cornerDots);
         this._createStyle({
           color: options.cornersDotOptions?.color,
-          name: `corners-dot-color-${column}-${row}`
+          name: `${this._classPrefix}-corners-dot-color-${column}-${row}`
         });
       }
 

--- a/src/index.html
+++ b/src/index.html
@@ -17,6 +17,8 @@
     <div id="container"></div>
     <hr />
     <div id="container2"></div>
+    <hr />
+    <div id="container3"></div>
 
     <script type="text/javascript">
       //Test out dot options
@@ -30,6 +32,10 @@
           color: "#123ddd"
         },
         cornersSquareOptions: {
+          type: "square",
+          color: "#321ccc"
+        },
+        cornersDotOptions: {
           type: "square",
           color: "#321ccc"
         },
@@ -72,6 +78,20 @@
 
         const qrCode = new QRCodeStyling(options);
         qrCode.append(container2);
+      });
+
+      // Draw SVG
+      const container3 = document.getElementById("container3");
+
+      dotOptions.forEach((dotOption, i) => {
+        options["dotsOptions"] = {
+          type: dotOptions[i],
+          color: color[i]
+        };
+        options.type = "svg";
+
+        const qrCode = new QRCodeStyling(options);
+        qrCode.append(container3);
       });
     </script>
   </body>


### PR DESCRIPTION
Hi @KilianB 

Thanks for maintaining this fork - it's been of great use in one of my projects.

I have a use case where I need multiple SVG based QR codes on one page. Currently, due to the inline SVG styles not being uniquely named, I cannot have these QR codes be different colours.
I've added a row of SVG codes to the bottom of demo page to show this - note how they all inherit the colour of the last QR code:

<img width="2054" alt="Before" src="https://github.com/KilianB/styled-qr-code/assets/971481/5c633344-2bb9-46e6-b08e-d2e0f568a621">

To fix this, I've created a small function that will generate a random character string, and prefix this to the CSS classes on a per QR code basis. This makes the styles unique and prevents clashes.
See the same demo with this change added:

<img width="2056" alt="After" src="https://github.com/KilianB/styled-qr-code/assets/971481/6bcecf04-4790-4bb9-aa16-018e8ee6bb22">



Thanks!

